### PR TITLE
Adding a retry on hadoop write failure

### DIFF
--- a/lib/backuptool.rb
+++ b/lib/backuptool.rb
@@ -110,7 +110,14 @@ class BackupTool
       remote = @hadoop.base_dir + '/' + snapshot.cluster + '/' + snapshot.node + '/' + file
       @logger.debug("#{local} => #{remote}")
       f = File.open(local, 'r')
-      @hadoop.create(remote, f, overwrite: true)
+      begin
+        retries = 3
+        @hadoop.create(remote, f, overwrite: true)
+      rescue
+        @logger.info("Hadoop write failed - retrying in 1s")
+        sleep 1
+        retry if (retries -= 1) < 0
+      end
       f.close
     end
 


### PR DESCRIPTION
Cassback is failing when trying to save generated snapshots files on hadoop : 

```
02:42:03    cassandra2-2.acme.prod    1. Backups cassandra2 cluster    Requested clearing snapshot(s) for [all keyspaces] with snapshot name [cass_snap]
02:42:04    cassandra2-2.acme.prod    1. Backups cassandra2 cluster    Requested creating snapshot(s) for [all keyspaces] with snapshot name [cass_snap]
02:42:09    cassandra2-2.acme.prod    1. Backups cassandra2 cluster    Snapshot directory: cass_snap
03:04:56    cassandra2-2.acme.prod    1. Backups cassandra2 cluster    [2016-09-06 01:04:56 +0000] 3  : Failed to connect to host myhadoop.acme.prod:14000, Broken pipe - sendfile
03:04:57            Remote command failed with exit status 1
03:04:57            Failed: NonZeroResultCode: Remote command failed with exit status 1
```

Since `@hadoop.create` is spawning a new http connection at every call ( https://github.com/kzk/webhdfs/blob/v0.8.0/lib/webhdfs/client_v1.rb#L259 + https://github.com/kzk/webhdfs/blob/v0.8.0/lib/webhdfs/client_v1.rb#L287 ), the retry might be working here !
